### PR TITLE
[Email Signature Generator] Add custom URL and label fields to signature data and update HTML

### DIFF
--- a/apps/email-signature-generator/src/App.tsx
+++ b/apps/email-signature-generator/src/App.tsx
@@ -36,6 +36,8 @@ const initialData: SignatureData = {
   personalPhone: "",
   medium: "",
   linkedin: "",
+  customUrl: "",
+  customUrlLabel: "",
 };
 
 export default function App() {

--- a/apps/email-signature-generator/src/components/SignatureForm.tsx
+++ b/apps/email-signature-generator/src/components/SignatureForm.tsx
@@ -23,10 +23,12 @@ import Typography from "@mui/material/Typography";
 import { motion } from "framer-motion";
 import {
   Briefcase,
+  Link,
   Linkedin,
   NotebookPen,
   Phone,
   Smartphone,
+  Tag,
   User,
 } from "lucide-react";
 import type { SignatureData } from "../types";
@@ -88,6 +90,21 @@ const fields: {
     placeholder: "https://linkedin.com/in/yourusername",
     type: "url",
     helper: "Your LinkedIn profile link",
+  },
+  {
+    id: "customUrl",
+    label: "Custom URL",
+    icon: <Link className="lucide" size={16} />,
+    placeholder: "https://github.com/yourusername",
+    type: "url",
+    helper: "Any other link you'd like to include",
+  },
+  {
+    id: "customUrlLabel",
+    label: "Link Label",
+    icon: <Tag className="lucide" size={16} />,
+    placeholder: "GitHub",
+    helper: "Display name for the link above",
   },
 ];
 
@@ -180,6 +197,7 @@ export default function SignatureForm({ data, onChange }: Props) {
             field.id === "designation" ||
             field.id === "medium" ||
             field.id === "linkedin";
+
           return (
             <Box
               key={field.id}

--- a/apps/email-signature-generator/src/types.ts
+++ b/apps/email-signature-generator/src/types.ts
@@ -21,4 +21,6 @@ export interface SignatureData {
   personalPhone: string;
   medium: string;
   linkedin: string;
+  customUrl: string;
+  customUrlLabel: string;
 }

--- a/apps/email-signature-generator/src/utils/__tests__/signatureGenerator.test.ts
+++ b/apps/email-signature-generator/src/utils/__tests__/signatureGenerator.test.ts
@@ -25,6 +25,8 @@ const base: SignatureData = {
   personalPhone: "",
   medium: "",
   linkedin: "",
+  customUrl: "",
+  customUrlLabel: "",
 };
 
 describe("generateSignatureHTML", () => {
@@ -99,5 +101,36 @@ describe("generateSignatureHTML", () => {
       linkedin: "https://linkedin.com/in/jane",
     });
     expect(html).toContain("Medium</a> | <a");
+  });
+
+  it("includes custom URL with label when both provided", () => {
+    const html = generateSignatureHTML({
+      ...base,
+      customUrl: "https://github.com/jane",
+      customUrlLabel: "GitHub",
+    });
+    expect(html).toContain('href="https://github.com/jane"');
+    expect(html).toContain(">GitHub<");
+  });
+
+  it("omits custom URL when only URL is provided without a label", () => {
+    const html = generateSignatureHTML({ ...base, customUrl: "https://github.com/jane" });
+    expect(html).not.toContain("https://github.com/jane");
+  });
+
+  it("omits custom URL when only label is provided without a URL", () => {
+    const html = generateSignatureHTML({ ...base, customUrlLabel: "GitHub" });
+    expect(html).not.toContain("GitHub");
+  });
+
+  it("appends custom link after LinkedIn with pipe separator", () => {
+    const html = generateSignatureHTML({
+      ...base,
+      linkedin: "https://linkedin.com/in/jane",
+      customUrl: "https://github.com/jane",
+      customUrlLabel: "GitHub",
+    });
+    expect(html).toContain("LinkedIn</a> | <a");
+    expect(html).toContain(">GitHub<");
   });
 });

--- a/apps/email-signature-generator/src/utils/signatureGenerator.ts
+++ b/apps/email-signature-generator/src/utils/signatureGenerator.ts
@@ -43,6 +43,12 @@ export function generateSignatureHTML(data: SignatureData): string {
       `<a href="${safeUrl}" style="color: #000000; text-decoration: none;">LinkedIn</a>`
     );
   }
+  if (data.customUrl && data.customUrlLabel) {
+    const safeUrl = isSafeUrl(data.customUrl) ? escapeHtml(data.customUrl) : "#";
+    socialLinks.push(
+      `<a href="${safeUrl}" style="color: #000000; text-decoration: none;">${escapeHtml(data.customUrlLabel)}</a>`
+    );
+  }
   const socialText = socialLinks.join(" | ");
 
   let phoneText = "";

--- a/apps/email-signature-generator/src/utils/signatureGenerator.ts
+++ b/apps/email-signature-generator/src/utils/signatureGenerator.ts
@@ -79,7 +79,7 @@ export function generateSignatureHTML(data: SignatureData): string {
           <tbody>
             <tr>
               <td style="${tdBase};padding: 0 0 3px 0;">
-                <img src="https://wso2.cachefly.net/wso2/sites/all/image_resources/logos/wso2-orange-logo.png" alt="WSO2" width="100" style="-ms-interpolation-mode: bicubic;height: auto;outline: none;text-decoration: none;border: 0;display: block;">
+                <a href="https://wso2.com" style="text-decoration: none;border: 0;display: block;"><img src="https://wso2.cachefly.net/wso2/sites/all/image_resources/logos/wso2-orange-logo.png" alt="WSO2" width="100" style="-ms-interpolation-mode: bicubic;height: auto;outline: none;text-decoration: none;border: 0;display: block;"></a>
               </td>
             </tr>
             <tr>

--- a/apps/email-signature-generator/src/utils/signatureGenerator.ts
+++ b/apps/email-signature-generator/src/utils/signatureGenerator.ts
@@ -34,19 +34,19 @@ export function generateSignatureHTML(data: SignatureData): string {
   if (data.medium) {
     const safeUrl = isSafeUrl(data.medium) ? escapeHtml(data.medium) : "#";
     socialLinks.push(
-      `<a href="${safeUrl}" style="color: #000000; text-decoration: none;">Medium</a>`
+      `<a href="${safeUrl}" style="color: #F04E23; text-decoration: none;">Medium</a>`
     );
   }
   if (data.linkedin) {
     const safeUrl = isSafeUrl(data.linkedin) ? escapeHtml(data.linkedin) : "#";
     socialLinks.push(
-      `<a href="${safeUrl}" style="color: #000000; text-decoration: none;">LinkedIn</a>`
+      `<a href="${safeUrl}" style="color: #F04E23; text-decoration: none;">LinkedIn</a>`
     );
   }
   if (data.customUrl && data.customUrlLabel) {
     const safeUrl = isSafeUrl(data.customUrl) ? escapeHtml(data.customUrl) : "#";
     socialLinks.push(
-      `<a href="${safeUrl}" style="color: #000000; text-decoration: none;">${escapeHtml(data.customUrlLabel)}</a>`
+      `<a href="${safeUrl}" style="color: #F04E23; text-decoration: none;">${escapeHtml(data.customUrlLabel)}</a>`
     );
   }
   const socialText = socialLinks.join(" | ");

--- a/apps/email-signature-generator/src/utils/signatureGenerator.ts
+++ b/apps/email-signature-generator/src/utils/signatureGenerator.ts
@@ -71,11 +71,11 @@ export function generateSignatureHTML(data: SignatureData): string {
   const textTd = (extra: string = "") =>
     `${tdBase};color: #000000 !important;font-family: Inter, Arial, sans-serif;line-height: 1.4;padding: 0 0 3px 0;${extra}`;
 
-  return `<table border="0" cellpadding="0" cellspacing="0" style="${tdBase};font-family: Arial, sans-serif;max-width: 400px;" width="100%">
+  return `<table border="0" cellpadding="0" cellspacing="0" style="${tdBase};font-family: Arial, sans-serif;">
   <tbody>
     <tr>
       <td style="${tdBase};padding: 0;margin: 0;">
-        <table border="0" cellpadding="0" cellspacing="0" style="${tdBase};" width="100%">
+        <table border="0" cellpadding="0" cellspacing="0" style="${tdBase};">
           <tbody>
             <tr>
               <td style="${tdBase};padding: 0 0 3px 0;">
@@ -97,9 +97,7 @@ export function generateSignatureHTML(data: SignatureData): string {
                 : ""
             }
             <tr>
-              <td style="${tdBase};padding: 0 0 3px 0;">
-                <hr style="border: none; border-top: 4px solid #F14E23; margin: 0; padding: 0; width: 100%; max-width: 400px;">
-              </td>
+              <td style="${tdBase};padding: 0 0 3px 0;border-bottom: 4px solid #F14E23;line-height: 0;font-size: 0;"></td>
             </tr>
             ${
               phoneText

--- a/apps/email-signature-generator/src/utils/signatureGenerator.ts
+++ b/apps/email-signature-generator/src/utils/signatureGenerator.ts
@@ -73,7 +73,7 @@ export function generateSignatureHTML(data: SignatureData): string {
   const textTd = (extra: string = "") =>
     `${tdBase};color: #000000 !important;font-family: Inter, Arial, sans-serif;line-height: 1.4;padding: 0 0 3px 0;${extra}`;
 
-  return `<table border="0" cellpadding="0" cellspacing="0" style="${tdBase};font-family: Arial, sans-serif;max-width: 400px;" width="100%">
+  return `<table border="0" cellpadding="0" cellspacing="0" style="${tdBase};font-family: Arial, sans-serif;">
   <tbody>
     <tr>
       <td style="${tdBase};padding: 0;margin: 0;">
@@ -100,7 +100,7 @@ export function generateSignatureHTML(data: SignatureData): string {
             }
             <tr>
               <td style="${tdBase};padding: 0 0 3px 0;">
-                <hr style="border: none; border-top: 4px solid #F14E23; margin: 0; padding: 0; width: 100%;">
+                <table border="0" cellpadding="0" cellspacing="0" width="100%" style="border-collapse: collapse;"><tbody><tr><td height="4" style="background-color: #F14E23; font-size: 0; line-height: 0; padding: 0; height: 4px;"></td></tr></tbody></table>
               </td>
             </tr>
             ${

--- a/apps/email-signature-generator/src/utils/signatureGenerator.ts
+++ b/apps/email-signature-generator/src/utils/signatureGenerator.ts
@@ -81,7 +81,7 @@ export function generateSignatureHTML(data: SignatureData): string {
           <tbody>
             <tr>
               <td style="${tdBase};padding: 0 0 3px 0;">
-                <a href="https://wso2.com" style="text-decoration: none;border: 0;display: block;"><img src="https://wso2.cachefly.net/wso2/sites/all/image_resources/logos/wso2-orange-logo.png" alt="WSO2" width="100" style="-ms-interpolation-mode: bicubic;height: auto;outline: none;text-decoration: none;border: 0;display: block;"></a>
+                <a href="https://wso2.com" style="text-decoration: none;border: 0;display: block;"><img src="https://wso2.cachefly.net/wso2/sites/all/image_resources/logos/wso2-orange-logo.png" alt="WSO2" width="100" height="25" style="-ms-interpolation-mode: bicubic;width: 100px;height: auto;outline: none;text-decoration: none;border: 0;display: block;"></a>
               </td>
             </tr>
             <tr>

--- a/apps/email-signature-generator/src/utils/signatureGenerator.ts
+++ b/apps/email-signature-generator/src/utils/signatureGenerator.ts
@@ -73,11 +73,11 @@ export function generateSignatureHTML(data: SignatureData): string {
   const textTd = (extra: string = "") =>
     `${tdBase};color: #000000 !important;font-family: Inter, Arial, sans-serif;line-height: 1.4;padding: 0 0 3px 0;${extra}`;
 
-  return `<table border="0" cellpadding="0" cellspacing="0" style="${tdBase};font-family: Arial, sans-serif;">
+  return `<table border="0" cellpadding="0" cellspacing="0" style="${tdBase};font-family: Arial, sans-serif;max-width: 400px;" width="100%">
   <tbody>
     <tr>
       <td style="${tdBase};padding: 0;margin: 0;">
-        <table border="0" cellpadding="0" cellspacing="0" style="${tdBase};">
+        <table border="0" cellpadding="0" cellspacing="0" style="${tdBase};" width="100%">
           <tbody>
             <tr>
               <td style="${tdBase};padding: 0 0 3px 0;">
@@ -99,7 +99,9 @@ export function generateSignatureHTML(data: SignatureData): string {
                 : ""
             }
             <tr>
-              <td style="${tdBase};padding: 0 0 1px 0;border-bottom: 4px solid #F14E23;line-height: 0;font-size: 0;"></td>
+              <td style="${tdBase};padding: 0 0 3px 0;">
+                <hr style="border: none; border-top: 4px solid #F14E23; margin: 0; padding: 0; width: 100%;">
+              </td>
             </tr>
             ${
               phoneText

--- a/apps/email-signature-generator/src/utils/signatureGenerator.ts
+++ b/apps/email-signature-generator/src/utils/signatureGenerator.ts
@@ -34,19 +34,21 @@ export function generateSignatureHTML(data: SignatureData): string {
   if (data.medium) {
     const safeUrl = isSafeUrl(data.medium) ? escapeHtml(data.medium) : "#";
     socialLinks.push(
-      `<a href="${safeUrl}" style="color: #F04E23; text-decoration: none;">Medium</a>`
+      `<a href="${safeUrl}" style="color: #F04E23; text-decoration: none;">Medium</a>`,
     );
   }
   if (data.linkedin) {
     const safeUrl = isSafeUrl(data.linkedin) ? escapeHtml(data.linkedin) : "#";
     socialLinks.push(
-      `<a href="${safeUrl}" style="color: #F04E23; text-decoration: none;">LinkedIn</a>`
+      `<a href="${safeUrl}" style="color: #F04E23; text-decoration: none;">LinkedIn</a>`,
     );
   }
   if (data.customUrl && data.customUrlLabel) {
-    const safeUrl = isSafeUrl(data.customUrl) ? escapeHtml(data.customUrl) : "#";
+    const safeUrl = isSafeUrl(data.customUrl)
+      ? escapeHtml(data.customUrl)
+      : "#";
     socialLinks.push(
-      `<a href="${safeUrl}" style="color: #F04E23; text-decoration: none;">${escapeHtml(data.customUrlLabel)}</a>`
+      `<a href="${safeUrl}" style="color: #F04E23; text-decoration: none;">${escapeHtml(data.customUrlLabel)}</a>`,
     );
   }
   const socialText = socialLinks.join(" | ");
@@ -97,7 +99,7 @@ export function generateSignatureHTML(data: SignatureData): string {
                 : ""
             }
             <tr>
-              <td style="${tdBase};padding: 0 0 3px 0;border-bottom: 4px solid #F14E23;line-height: 0;font-size: 0;"></td>
+              <td style="${tdBase};padding: 0 0 1px 0;border-bottom: 4px solid #F14E23;line-height: 0;font-size: 0;"></td>
             </tr>
             ${
               phoneText


### PR DESCRIPTION
This pull request adds support for a custom URL and label in the email signature generator, allowing users to include an additional link (such as a GitHub profile) in their generated signature. The changes span the data model, form UI, signature generation logic, and tests to ensure correct behavior.

**Feature: Add custom URL and label support**

* Added `customUrl` and `customUrlLabel` fields to the `SignatureData` type and initialized them in all relevant locations (`App.tsx`, `types.ts`, and test base data) [[1]](diffhunk://#diff-f6ce77868093a9f723be1ccc6f1aa41d1ed255f796ae39f1deb4c1761a028feeR39-R40) [[2]](diffhunk://#diff-c4c98bc5e92bfe957da5971fd10ec5e768637acc55ca9cee05e2489385479b3cR24-R25) [[3]](diffhunk://#diff-9c63d450460f52ed93e5644a2e0cde2ecc2d236108242ab7cd207e23a6790a11R28-R29).
* Updated the signature form to include new fields for custom URL and label, with appropriate icons and helper text [[1]](diffhunk://#diff-1d8c955166fa5ba8adcc1700aa0a48bf34c9820aa12a01d9d09eb120772606d1R26-R31) [[2]](diffhunk://#diff-1d8c955166fa5ba8adcc1700aa0a48bf34c9820aa12a01d9d09eb120772606d1R94-R108).
* Modified the signature generation logic to append the custom link (with label) to the social links section, only if both fields are provided.

**Testing: Ensure correct custom URL behavior**

* Added tests to verify that the custom URL is included only when both the URL and label are provided, omitted otherwise, and appended after LinkedIn with a separator.

**Other improvements**

* Made the company logo in the signature a clickable link to the company website for improved branding.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added custom URL and custom URL label fields so users can include personalized links with custom descriptions.
  * Made the signature logo clickable, opening the WSO2 website.

* **Style**
  * Updated social link color to orange and adjusted the signature separator for improved visual consistency.

* **Tests**
  * Added/updated tests verifying custom URL/label rendering and placement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->